### PR TITLE
fix nested array record item

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -186,6 +186,10 @@ final class Validator implements ValidatorInterface
                 if ('array' === $type['type'] && is_array($fieldValue)) {
                     $types = (array) $type['items'];
 
+                    if (isset($types['type']) && 'record' === $types['type']) {
+                        $types = [$types];
+                    }
+
                     foreach ($fieldValue as $key => $value) {
                         $itemPath = sprintf('%s[%s]', $currentPath, $key);
                         if (false === $this->checkFieldValueBeOneOf($types, $value, $itemPath, $validationErrors)) {


### PR DESCRIPTION
Current behaviour for getting the array types:
```
string: [string]
[int,string]: [int,string]
record: record
```

With this fix:
```
string: [string]
[int, string]: [int,string]
record: [record]
```

Since record is already an array, the current cast would do nothing, but in the record case, it needs to nest the record into another array. Otherwise, the recursion of `checkFieldValueBeOneOf` will not have a valid types array and will not properly recognize the record.